### PR TITLE
Update snt_internet_dns.html

### DIFF
--- a/snt_internet_dns.html
+++ b/snt_internet_dns.html
@@ -84,7 +84,7 @@
 			Comme vous pouvez le constater, l'adresse IP de la machine "ac-grenoble.fr" est bien 193.54.149.86
 		</p>
 		<p>
-			Il est aussi possible d'effectuer ce genre de traduction sur un site web :  <a href="https://www.whois.com/whois/" target="_blank">https://www.whois.com/whois/</a>
+			Pour certaines adresses publiques, Il est possible d'effectuer ce genre de traduction sur un site web :  <a href="https://www.whois.com/whois/" target="_blank">https://www.whois.com/whois/</a>
 		</p>
 		<h4>À faire vous-même 3</h4>
 		<p>


### PR DESCRIPTION
Indication de la restriction du whois pour la résolution DNS à certaines adresses publiques. Ça ne fonctionne pas avec toutes les adresses ! On peut aussi prendre http://dnslookup.fr/